### PR TITLE
Add Helm ingress

### DIFF
--- a/deployment/helm/Chart.yaml
+++ b/deployment/helm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: cloudfloo
+description: A Helm chart for CloudFloo deployment
+version: 0.1.1
+appVersion: "1.0"

--- a/deployment/helm/templates/_helpers.tpl
+++ b/deployment/helm/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{- define "cloudfloo.name" -}}
+{{- default .Chart.Name .Values.nameOverride -}}
+{{- end -}}
+
+{{- define "cloudfloo.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "cloudfloo.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version -}}
+{{- end -}}

--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "cloudfloo.fullname" . }}
+  labels:
+    app: {{ include "cloudfloo.name" . }}
+    chart: {{ include "cloudfloo.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "cloudfloo.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "cloudfloo.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 3000
+          name: http
+        resources: {{- toYaml .Values.resources | nindent 10 }}

--- a/deployment/helm/templates/ingress.yaml
+++ b/deployment/helm/templates/ingress.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "cloudfloo.fullname" . }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+{{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "cloudfloo.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/deployment/helm/templates/service.yaml
+++ b/deployment/helm/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "cloudfloo.fullname" . }}
+  labels:
+    app: {{ include "cloudfloo.name" . }}
+    chart: {{ include "cloudfloo.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ include "cloudfloo.name" . }}
+    release: {{ .Release.Name }}

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -1,0 +1,19 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/cloudfloo/cloudfloo.io
+  tag: latest
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources: {}
+
+ingress:
+  enabled: true
+  className: nginx
+  host: cloudfloo.io
+  annotations: {}
+


### PR DESCRIPTION
## Summary
- set Helm chart version to 0.1.1
- default image tag `latest`
- add Nginx ingress with configurable host

## Testing
- `npm test`
- `npm run lint`
- `helm lint deployment/helm`
- `helm template test deployment/helm`


------
https://chatgpt.com/codex/tasks/task_e_6852976097048325917a9b120f14d3f2