### PR TITLE
Fix helm namespaces for Argo

### DIFF
--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "cloudfloo.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "cloudfloo.name" . }}
     chart: {{ include "cloudfloo.chart" . }}

--- a/deployment/helm/templates/ingress.yaml
+++ b/deployment/helm/templates/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "cloudfloo.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.ingress.annotations }}
   annotations:
 {{ toYaml . | indent 4 }}

--- a/deployment/helm/templates/service.yaml
+++ b/deployment/helm/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "cloudfloo.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "cloudfloo.name" . }}
     chart: {{ include "cloudfloo.chart" . }}


### PR DESCRIPTION
## Summary
- add metadata.namespace to the helm templates so ArgoCD can sync resources

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852a620beb4832590e286dfea5397fc