### PR TITLE
Fix LHCI path

### DIFF
--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -2,7 +2,7 @@ module.exports = {
   ci: {
     collect: {
       staticDistDir: './out',
-      url: ['./out/index.html'],
+      url: ['/index.html'],
       numberOfRuns: 3,
     },
     assert: {


### PR DESCRIPTION
## Summary
- fix the URL in `lighthouserc.js`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6853291cce94832584c07a4bfccb0900