### PR TITLE
Fix Playwright CI server reuse issue

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -76,7 +76,7 @@ export default defineConfig({
   webServer: {
     command: 'npm run dev',
     url: 'http://localhost:3000',
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: true,
     timeout: 120 * 1000,
   },
 });


### PR DESCRIPTION
## Summary
- reuse existing web server when running playwright

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6853f50c9dd8832589e289d30b150d11