### PR TITLE
Fix nginx port mismatch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ RUN npm run static
 
 # Production image with nginx to serve static files
 FROM nginx:alpine AS runner
-WORKDIR /usr/share/nginx/html
-COPY --from=builder /app/out .
+COPY --from=builder /app/out/ /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/nginx.conf
-EXPOSE 80
+EXPOSE 3000
 CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ npm start
 docker build -t cloudfloo.io .
 
 # Run the Docker container
+# Expose port 3000 from the container
 docker run -p 3000:3000 cloudfloo.io
 ```
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -30,7 +30,7 @@ http {
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
 
     server {
-        listen 80;
+        listen 3000;
         server_name _;
         root /usr/share/nginx/html;
         index index.html;


### PR DESCRIPTION
## Summary
- expose port 3000 in Dockerfile
- update nginx config to listen on 3000
- clarify Docker run command in README

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Missing script)*
- `npm run build`
- `npm run lighthouse` *(fails: Chrome installation not found)*
- `npm test`
- `npm run test:a11y` *(fails: Missing script)*
- `npm run test:e2e` *(fails: Do not import `@jest/globals` outside of the Jest test environment)*

------
https://chatgpt.com/codex/tasks/task_e_6854545120448325bf9a31314ee45b30