### PR TITLE
Optimize cloud animation

### DIFF
--- a/components/CloudSceneImpl.tsx
+++ b/components/CloudSceneImpl.tsx
@@ -40,8 +40,16 @@ export default function ImmersiveCloudVisualization({ className = '' }: Immersiv
       worker.postMessage({ type: 'mouse', x, y });
     };
 
+    const handleScroll = () => {
+      const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+      const docHeight = document.documentElement.scrollHeight - window.innerHeight;
+      const scrollRatio = docHeight > 0 ? scrollTop / docHeight : 0;
+      worker.postMessage({ type: 'scroll', value: scrollRatio });
+    };
+
     window.addEventListener('resize', handleResize);
     window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('scroll', handleScroll);
     setIsLoaded(true);
 
     return () => {
@@ -49,6 +57,7 @@ export default function ImmersiveCloudVisualization({ className = '' }: Immersiv
       worker.terminate();
       window.removeEventListener('resize', handleResize);
       window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('scroll', handleScroll);
       if (canvasRef.current && mountNode) {
         mountNode.removeChild(canvasRef.current);
       }

--- a/components/cloud-worker.ts
+++ b/components/cloud-worker.ts
@@ -10,10 +10,15 @@ let animationId: number;
 const nav = (self as any).navigator || {};
 const hardware = nav.hardwareConcurrency ?? 8;
 const memory = nav.deviceMemory ?? 8;
-const isLowEnd = hardware <= 4 || memory <= 4;
+const config = {
+  lowEndThresholds: { hardware: 4, memory: 4 },
+  particleCounts: { lowEnd: 15000, highEnd: 30000 },
+  frameIntervals: { lowEnd: 1000 / 30, highEnd: 1000 / 60 },
+};
 
-const PARTICLE_COUNT = isLowEnd ? 15000 : 30000;
-const FRAME_INTERVAL = isLowEnd ? 1000 / 30 : 1000 / 60;
+const isLowEnd = hardware <= config.lowEndThresholds.hardware || memory <= config.lowEndThresholds.memory;
+const PARTICLE_COUNT = isLowEnd ? config.particleCounts.lowEnd : config.particleCounts.highEnd;
+const FRAME_INTERVAL = isLowEnd ? config.frameIntervals.lowEnd : config.frameIntervals.highEnd;
 let lastFrame = 0;
 
 // Creating thousands of particles at once can block the worker event loop for

--- a/components/cloud-worker.ts
+++ b/components/cloud-worker.ts
@@ -7,7 +7,14 @@ let cloud: THREE.Points | undefined;
 let mouse = new THREE.Vector2();
 let animationId: number;
 
-const PARTICLE_COUNT = 30000;
+const nav = (self as any).navigator || {};
+const hardware = nav.hardwareConcurrency ?? 8;
+const memory = nav.deviceMemory ?? 8;
+const isLowEnd = hardware <= 4 || memory <= 4;
+
+const PARTICLE_COUNT = isLowEnd ? 15000 : 30000;
+const FRAME_INTERVAL = isLowEnd ? 1000 / 30 : 1000 / 60;
+let lastFrame = 0;
 
 // Creating thousands of particles at once can block the worker event loop for
 // noticeable time. We generate them in chunks during idle periods to keep the
@@ -138,7 +145,7 @@ async function createCloudSystem(): Promise<THREE.Points> {
         vec3 mixB = mix(color3, color4, sin(colorPhase * 1.3) * 0.5 + 0.5);
         vColor = mix(mixA, mixB, sin(colorPhase * 0.7 + aRandom.y * 3.0) * 0.5 + 0.5);
 
-        vBrightness = randomLighting(pos, aRandom) * 0.6 + 0.3;
+        vBrightness = randomLighting(pos, aRandom) * 0.5 + 0.2;
       }
     `,
     fragmentShader: `
@@ -164,9 +171,9 @@ async function createCloudSystem(): Promise<THREE.Points> {
 
         float pulse = sin(uTime * 1.5 + vDistance * 0.05 + vRandom.z * 5.0) * 0.2 + 0.8;
 
-        vec3 finalColor = vColor * vBrightness;
+        vec3 finalColor = vColor * vBrightness * 0.8;
 
-        float finalAlpha = alpha * distanceFade * pulse * 0.1;
+        float finalAlpha = alpha * distanceFade * pulse * 0.07;
 
         gl_FragColor = vec4(finalColor, finalAlpha);
       }
@@ -177,19 +184,25 @@ async function createCloudSystem(): Promise<THREE.Points> {
   return cloud;
 }
 
-function animate() {
+function animate(time: number = 0) {
   if (!scene || !camera || !renderer || !cloud) return;
 
-  const time = Date.now() * 0.001;
+  if (time - lastFrame < FRAME_INTERVAL) {
+    animationId = requestAnimationFrame(animate);
+    return;
+  }
+  lastFrame = time;
+
+  const t = time * 0.001;
 
   if ((cloud.material as THREE.ShaderMaterial).uniforms) {
-    (cloud.material as THREE.ShaderMaterial).uniforms.uTime.value = time;
+    (cloud.material as THREE.ShaderMaterial).uniforms.uTime.value = t;
     (cloud.material as THREE.ShaderMaterial).uniforms.uMouse.value = mouse;
   }
 
-  camera.position.x = Math.sin(time * 0.15) * 8;
-  camera.position.y = Math.cos(time * 0.12) * 6;
-  camera.position.z = 50 + Math.sin(time * 0.08) * 4;
+  camera.position.x = Math.sin(t * 0.15) * 8;
+  camera.position.y = Math.cos(t * 0.12) * 6;
+  camera.position.z = 50 + Math.sin(t * 0.08) * 4;
   camera.lookAt(0, 0, 0);
 
   renderer.render(scene, camera);
@@ -220,7 +233,8 @@ async function init(canvas: OffscreenCanvas | undefined, width: number, height: 
     if (renderer.domElement) {
       const hasStyle = (renderer.domElement as any).style !== undefined;
       renderer.setSize(width, height, hasStyle);
-      renderer.setPixelRatio(Math.min((self as any).devicePixelRatio || 1, 2));
+      const pixelRatio = isLowEnd ? 1 : Math.min((self as any).devicePixelRatio || 1, 2);
+      renderer.setPixelRatio(pixelRatio);
       renderer.setClearColor(0x000000, 0);
     } else {
       console.error('WebGLRenderer created without a canvas');
@@ -236,7 +250,7 @@ async function init(canvas: OffscreenCanvas | undefined, width: number, height: 
   cloud = await createCloudSystem();
   scene.add(cloud);
 
-  animate();
+  animate(0);
 }
 
 function resize(width: number, height: number) {
@@ -276,6 +290,11 @@ self.onmessage = (event: MessageEvent) => {
     case 'mouse':
       mouse.x = data.x;
       mouse.y = data.y;
+      break;
+    case 'scroll':
+      if (cloud && (cloud.material as THREE.ShaderMaterial).uniforms) {
+        (cloud.material as THREE.ShaderMaterial).uniforms.uScroll.value = data.value;
+      }
       break;
     case 'dispose':
       dispose();


### PR DESCRIPTION
## Summary
- handle scroll events in `CloudSceneImpl` to resize the cloud animation
- optimize cloud worker by reducing particles on low-end devices
- lower brightness and limit framerate for better performance

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:e2e` *(fails: Do not import `@jest/globals` outside of the Jest test environment)*
- `npm run test:a11y` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855118255c883259e8d41b8d52f9195