### PR TITLE
Improve lighthouse performance with dynamic imports

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,14 +1,15 @@
 import EnhancedHeader from '@/components/enhanced-header-fixed';
 import Hero from '@/components/hero';
-import EnhancedServices from '@/components/enhanced-services';
-import EnhancedAbout from '@/components/enhanced-about';
-import TeamCard from '@/components/TeamCard';
-import { team } from '@/data/team';
-import EnhancedProjects from '@/components/enhanced-projects';
-import FAQSection from '@/components/faq-section';
-import EnhancedContact from '@/components/enhanced-contact';
+import dynamic from 'next/dynamic';
 import Footer from '@/components/footer';
 import SEO from '@/components/SEO';
+
+const EnhancedServices = dynamic(() => import('@/components/enhanced-services'), { ssr: false });
+const EnhancedAbout = dynamic(() => import('@/components/enhanced-about'), { ssr: false });
+const TeamSection = dynamic(() => import('@/components/TeamSection'), { ssr: false });
+const EnhancedProjects = dynamic(() => import('@/components/enhanced-projects'), { ssr: false });
+const FAQSection = dynamic(() => import('@/components/faq-section'), { ssr: false });
+const EnhancedContact = dynamic(() => import('@/components/enhanced-contact'), { ssr: false });
 
 export default function Home() {
   return (
@@ -21,19 +22,7 @@ export default function Home() {
       <Hero />
       <EnhancedServices />
       <EnhancedAbout />
-      
-      {/* Team Section */}
-      <section id="team" className="py-16 bg-black/30">
-        <div className="container mx-auto px-6">
-          <h2 className="text-4xl md:text-5xl font-bold mb-8 text-center">
-            Our <span className="text-neon">team</span>
-          </h2>
-          <div className="grid gap-6 md:grid-cols-3">
-            {team.map(p => <TeamCard key={p.slug} person={p} />)}
-          </div>
-        </div>
-      </section>
-      
+      <TeamSection />
       <EnhancedProjects />
       <FAQSection />
       <EnhancedContact />

--- a/components/TeamSection.tsx
+++ b/components/TeamSection.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import TeamCard from './TeamCard';
+import { team } from '@/data/team';
+
+export default function TeamSection() {
+  return (
+    <section id="team" className="py-16 bg-black/30">
+      <div className="container mx-auto px-6">
+        <h2 className="text-4xl md:text-5xl font-bold mb-8 text-center">
+          Our <span className="text-neon">team</span>
+        </h2>
+        <div className="grid gap-6 md:grid-cols-3">
+          {team.map(person => (
+            <TeamCard key={person.slug} person={person} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/tests/headers.spec.ts
+++ b/tests/headers.spec.ts
@@ -4,6 +4,7 @@ import config from '../next.config.js';
 test('headers configuration', async () => {
   const headers = config.customHeaders;
   const linkRule = headers.find(h => h.source === '/:path*');
-  expect(linkRule.headers[0].key).toBe('Link');
-  expect(linkRule.headers[0].value).toContain('https://images.pexels.com');
+  expect(linkRule).toBeDefined();
+  expect(linkRule!.headers[0].key).toBe('Link');
+  expect(linkRule!.headers[0].value).toContain('https://images.pexels.com');
 });

--- a/tests/immersive.spec.ts
+++ b/tests/immersive.spec.ts
@@ -1,6 +1,6 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Page } from '@playwright/test';
 
-const waitForCanvas = async (page) => {
+const waitForCanvas = async (page: Page) => {
   await page.waitForSelector('canvas', { timeout: 5000 });
 };
 


### PR DESCRIPTION
## Summary
- create `TeamSection` component for team listing
- dynamically import heavy sections in home page to trim main bundle
- update tests for type safety

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build`
- `npm test`
- `npm run lighthouse` *(fails: Chrome installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855221574108325bfff1f806e142ee3