### PR TITLE
Fix Playwright running Jest tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './tests',
-  testMatch: '**/*.spec.ts',
+  testMatch: ['**/*.spec.ts'],
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   testDir: './tests',
+  testMatch: '**/*.spec.ts',
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */


### PR DESCRIPTION
## Summary
- prevent Playwright from executing Jest test files by specifying `testMatch`

## Testing
- `npm run lint`
- `npm run type-check` *(fails: Missing script)*
- `npm run build`
- `npm test`
- `npm run test:e2e` *(partially run)*
- `npm run test:a11y` *(fails: Missing script)*
- `npm run lighthouse` *(fails: Chrome installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554787da7c832586acd4a07f6597c4