### PR TITLE
Add translated success toast for contact form

### DIFF
--- a/components/contact.tsx
+++ b/components/contact.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import { toast } from '@/hooks/use-toast';
+import { useLanguage } from '@/contexts/LanguageContext';
 
 export default function Contact() {
   const [formData, setFormData] = useState({
@@ -14,6 +15,7 @@ export default function Contact() {
     company: '',
     message: ''
   });
+  const { t } = useLanguage();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -34,13 +36,13 @@ export default function Contact() {
       );
 
       if (res.ok) {
-        toast({ title: 'Success' });
+        toast({ title: t('contact.form.success') });
         setFormData({ name: '', email: '', company: '', message: '' });
       } else {
-        toast({ title: 'Error', variant: 'destructive' });
+        toast({ title: t('common.error'), variant: 'destructive' });
       }
     } catch (error) {
-      toast({ title: 'Error', variant: 'destructive' });
+      toast({ title: t('common.error'), variant: 'destructive' });
     }
   };
 

--- a/components/enhanced-contact.tsx
+++ b/components/enhanced-contact.tsx
@@ -39,7 +39,7 @@ export default function EnhancedContact() {
       );
 
       if (res.ok) {
-        toast({ title: t('common.success') });
+        toast({ title: t('contact.form.success') });
         setFormData({ name: '', email: '', company: '', message: '' });
       } else {
         toast({ title: t('common.error'), variant: 'destructive' });

--- a/contexts/LanguageContext.tsx
+++ b/contexts/LanguageContext.tsx
@@ -65,7 +65,8 @@ const defaultTranslations = {
       companyPlaceholder: 'Your company',
       messageRequired: 'Message *',
       messagePlaceholder: 'Tell us about your project...',
-      submit: 'Send Message'
+      submit: 'Send Message',
+      success: 'Message sent successfully!'
     },
     info: {
       title: 'Contact Information',

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -203,6 +203,7 @@
       "companyPlaceholder": "Your company",
       "messagePlaceholder": "Tell us about your project...",
       "submit": "Send Message"
+      ,"success": "Message sent successfully!"
     },
     "info": {
       "title": "Contact Information",

--- a/public/translations/pl.json
+++ b/public/translations/pl.json
@@ -203,6 +203,7 @@
       "companyPlaceholder": "Twoja firma",
       "messagePlaceholder": "Opowiedz nam o swoim projekcie...",
       "submit": "Wyślij wiadomość"
+      ,"success": "Wiadomość została wysłana pomyślnie!"
     },
     "info": {
       "title": "Informacje kontaktowe",


### PR DESCRIPTION
## Summary
- show success toast with translations in contact forms
- add new translation key for contact form success message

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:e2e` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/...)*
- `npm run type-check` *(fails: Missing script)*
- `npm run test:a11y` *(fails: Missing script)*
- `npm run lighthouse` *(fails: Chrome installation not found)*

------
https://chatgpt.com/codex/tasks/task_e_68664ded585083258d5853ca52085f7c