### PR TITLE
Fix sitemap generation for static export

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
   siteUrl: process.env.SITE_URL || 'https://cloudfloo.io',
+  // Output sitemaps to the static export directory so they are
+  // included in the final Docker image served by nginx
+  outDir: './out',
   generateRobotsTxt: true,
   changefreq: 'weekly',
   priority: 0.7,

--- a/next-sitemap.config.mjs
+++ b/next-sitemap.config.mjs
@@ -1,6 +1,9 @@
 /** @type {import('next-sitemap').IConfig} */
 export default {
   siteUrl: 'https://cloudfloo.io',
+  // Output sitemaps to the static export directory so they are
+  // served correctly when using `next export`
+  outDir: './out',
   generateRobotsTxt: true,
   generateIndexSitemap: false,
   exclude: ['/server-sitemap.xml'],
@@ -35,3 +38,4 @@ export default {
     ],
   },
 } 
+


### PR DESCRIPTION
## Summary
- ensure `next-sitemap` writes files to the `out` directory
- keep the sitemap in the Docker image

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6867b4bb01d08325b55fa89bbde52ba5