### PR TITLE
Improve LCP by deferring cloud visualization

### DIFF
--- a/app/en/page.tsx
+++ b/app/en/page.tsx
@@ -1,17 +1,14 @@
 import { Metadata } from 'next';
 import { generatePageMetadata } from '@/lib/metadata';
 import dynamic from 'next/dynamic';
+import ImmersiveCloudVisualization from '@/components/immersive-cloud-visualization';
 
 // Critical components - load immediately
 import EnhancedHeader from '@/components/enhanced-header-fixed';
 import Hero from '@/components/hero';
 import Footer from '@/components/footer';
 
-// Cloud visualization - lazy load when needed
-const ImmersiveCloudVisualization = dynamic(() => import('@/components/immersive-cloud-visualization'), { 
-  ssr: false,
-  loading: () => null
-});
+// Cloud visualization loaded lazily inside the component itself
 
 // Above-the-fold components - load with priority
 const EnhancedServices = dynamic(() => import('@/components/enhanced-services'), { 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import { generatePageMetadata } from '@/lib/metadata';
 import dynamic from 'next/dynamic';
+import ImmersiveCloudVisualization from '@/components/immersive-cloud-visualization';
 
 // Critical components - load immediately
 import EnhancedHeader from '@/components/enhanced-header-fixed';
@@ -8,11 +9,7 @@ import Hero from '@/components/hero';
 import Footer from '@/components/footer';
 import PolishLanguageWrapper from '@/components/PolishLanguageWrapper';
 
-// Cloud visualization - lazy load when needed
-const ImmersiveCloudVisualization = dynamic(() => import('@/components/immersive-cloud-visualization'), { 
-  ssr: false,
-  loading: () => null
-});
+// Cloud visualization loaded lazily inside the component itself
 
 // Above-the-fold components - load with priority
 const EnhancedServices = dynamic(() => import('@/components/enhanced-services'), { 

--- a/components/immersive-cloud-visualization.tsx
+++ b/components/immersive-cloud-visualization.tsx
@@ -1,6 +1,34 @@
-import dynamic from 'next/dynamic';
+"use client";
 
-export default dynamic(() => import('./CloudSceneImpl'), {
-  ssr: false,
-  loading: () => null
-});
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Lazily load the heavy cloud visualization only when the container becomes
+ * visible in the viewport. This keeps the initial bundle small and avoids
+ * blocking the main thread during first paint.
+ */
+export default function ImmersiveCloudVisualization() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [Scene, setScene] = useState<React.ComponentType | null>(null);
+
+  useEffect(() => {
+    const load = () => import("./CloudSceneImpl").then(m => setScene(() => m.default));
+
+    if ("IntersectionObserver" in window && containerRef.current) {
+      const observer = new IntersectionObserver(entries => {
+        if (entries[0].isIntersecting) {
+          load();
+          observer.disconnect();
+        }
+      }, { rootMargin: "200px" });
+
+      observer.observe(containerRef.current);
+      return () => observer.disconnect();
+    }
+
+    const id = setTimeout(load, 2000);
+    return () => clearTimeout(id);
+  }, []);
+
+  return <div ref={containerRef} className="fixed inset-0 z-0">{Scene && <Scene />}</div>;
+}


### PR DESCRIPTION
## Summary
- lazy load `CloudSceneImpl` via IntersectionObserver
- remove dynamic import wrapper for `ImmersiveCloudVisualization`

## Testing
- `npm run lint`
- `npm test`
- `npm run test:e2e` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_6867bb861fcc8325b3b9e6ce7de7bf77