### PR TITLE
Add Polish translations for blog and legal pages

### DIFF
--- a/app/company/blog/page.tsx
+++ b/app/company/blog/page.tsx
@@ -9,18 +9,20 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import SEO from '@/components/SEO';
+import { useLanguage } from '@/contexts/LanguageContext';
 
 export default function BlogPage() {
+  const { t } = useLanguage();
   const [selectedCategory, setSelectedCategory] = useState('all');
   const [searchTerm, setSearchTerm] = useState('');
 
   const categories = [
-    { id: 'all', label: 'All Posts' },
-    { id: 'cloud', label: 'Cloud Computing' },
-    { id: 'ai', label: 'AI & Machine Learning' },
-    { id: 'devops', label: 'DevOps' },
-    { id: 'security', label: 'Security' },
-    { id: 'tutorials', label: 'Tutorials' }
+    { id: 'all', label: t('blog.categories.all') },
+    { id: 'cloud', label: t('blog.categories.cloud') },
+    { id: 'ai', label: t('blog.categories.ai') },
+    { id: 'devops', label: t('blog.categories.devops') },
+    { id: 'security', label: t('blog.categories.security') },
+    { id: 'tutorials', label: t('blog.categories.tutorials') }
   ];
 
   const blogPosts = [
@@ -123,21 +125,20 @@ export default function BlogPage() {
         <div className="absolute inset-0 bg-gradient-to-br from-purple-900/20 via-transparent to-pink-900/20"></div>
         <div className="container mx-auto px-6 relative z-10">
           <div className="max-w-4xl mx-auto text-center">
-            <motion.h1 
+            <motion.h1
               className="text-5xl md:text-6xl font-bold mb-6"
               initial={{ opacity: 0, y: 30 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6 }}
-            >
-              CloudFloo <span className="text-neon">Blog</span>
-            </motion.h1>
-            <motion.p 
+              dangerouslySetInnerHTML={{ __html: t('blog.heroTitle') }}
+            />
+            <motion.p
               className="text-xl text-gray-300 mb-8 leading-relaxed"
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.6, delay: 0.2 }}
             >
-              Insights, tutorials, and thought leadership on cloud computing, AI, and modern software development.
+              {t('blog.heroSubtitle')}
             </motion.p>
           </div>
         </div>
@@ -146,16 +147,16 @@ export default function BlogPage() {
       {/* Featured Posts Carousel */}
       <section className="py-20 bg-black/30">
         <div className="container mx-auto px-6">
-          <motion.div 
+          <motion.div
             className="text-center mb-16"
             initial={{ opacity: 0, y: 30 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.6 }}
           >
-            <h2 className="text-4xl font-bold mb-6">Featured Posts</h2>
+            <h2 className="text-4xl font-bold mb-6">{t('blog.featuredTitle')}</h2>
             <p className="text-xl text-gray-300 max-w-3xl mx-auto">
-              Our latest insights and deep dives into cutting-edge technology.
+              {t('blog.featuredSubtitle')}
             </p>
           </motion.div>
 
@@ -179,7 +180,7 @@ export default function BlogPage() {
                     />
                     <div className="absolute top-4 left-4">
                       <Badge className="bg-gradient-neon text-white">
-                        Featured
+                        {t('blog.featured')}
                       </Badge>
                     </div>
                   </div>
@@ -221,7 +222,7 @@ export default function BlogPage() {
                       size="sm" 
                       className="w-full bg-transparent border border-neon text-neon hover:bg-neon hover:text-black transition-all duration-300 group/btn"
                     >
-                      Read More
+                      {t('blog.readMore')}
                       <ArrowRight className="ml-2 w-4 h-4 transition-transform group-hover/btn:translate-x-1" />
                     </Button>
                   </CardContent>
@@ -247,7 +248,7 @@ export default function BlogPage() {
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-5 h-5" />
               <Input
                 type="text"
-                placeholder="Search articles..."
+                placeholder={t('blog.searchPlaceholder')}
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
                 className="pl-10 bg-white/5 border-gray-600 text-white placeholder-gray-400 focus:border-neon focus:ring-neon/20"
@@ -343,7 +344,7 @@ export default function BlogPage() {
                 animate={{ opacity: 1 }}
                 transition={{ duration: 0.6 }}
               >
-                <p className="text-gray-400 text-lg">No posts found matching your criteria.</p>
+                <p className="text-gray-400 text-lg">{t('blog.noPosts')}</p>
               </motion.div>
             )}
           </div>
@@ -360,18 +361,18 @@ export default function BlogPage() {
             viewport={{ once: true }}
             transition={{ duration: 0.6 }}
           >
-            <h2 className="text-4xl font-bold mb-6">Stay Updated</h2>
+            <h2 className="text-4xl font-bold mb-6">{t('blog.stayUpdatedTitle')}</h2>
             <p className="text-xl text-gray-300 mb-8">
-              Subscribe to our newsletter for the latest insights and updates.
+              {t('blog.stayUpdatedSubtitle')}
             </p>
             <div className="flex flex-col sm:flex-row gap-4 max-w-md mx-auto">
               <Input
                 type="email"
-                placeholder="Enter your email"
+                placeholder={t('blog.newsletterPlaceholder')}
                 className="bg-white/5 border-gray-600 text-white placeholder-gray-400 focus:border-neon focus:ring-neon/20"
               />
               <Button className="bg-gradient-neon text-white hover:shadow-lg hover:shadow-cyan-500/25 transition-all duration-300">
-                Subscribe
+                {t('blog.subscribe')}
               </Button>
             </div>
           </motion.div>

--- a/app/legal/cookies/page.tsx
+++ b/app/legal/cookies/page.tsx
@@ -61,7 +61,7 @@ export default function CookiePolicyPage() {
           <div className="flex items-center space-x-4">
             <BackToHomeButton />
             <div className="text-gray-500">/</div>
-            <div className="text-neon">Cookie Policy</div>
+            <div className="text-neon">{t('common.cookies')}</div>
           </div>
         </div>
       </header>
@@ -73,9 +73,12 @@ export default function CookiePolicyPage() {
             <div className="w-16 h-16 bg-gradient-to-r from-orange-500 to-red-500 rounded-2xl flex items-center justify-center mx-auto mb-6">
               <Cookie className="w-8 h-8 text-white" />
             </div>
-            <h1 className="text-4xl md:text-5xl font-bold mb-4">Cookie Policy</h1>
+            <h1
+              className="text-4xl md:text-5xl font-bold mb-4"
+              dangerouslySetInnerHTML={{ __html: t('legal.cookies.heroTitle') }}
+            />
             <p className="text-xl text-gray-300 mb-4">
-              Learn about how we use cookies and similar technologies to improve your experience.
+              {t('legal.cookies.heroSubtitle')}
             </p>
             <p className="text-sm text-gray-400">
               Last updated: {new Date(lastUpdated).toLocaleDateString('en-US', { 

--- a/app/legal/gdpr/client.tsx
+++ b/app/legal/gdpr/client.tsx
@@ -29,11 +29,12 @@ export default function GDPRClient() {
             <div className="w-20 h-20 bg-gradient-to-r from-blue-500 to-green-500 rounded-2xl flex items-center justify-center mx-auto mb-8">
               <Shield className="w-10 h-10 text-white" />
             </div>
-            <h1 className="text-5xl md:text-6xl font-bold mb-6 text-white">
-              GDPR <span className="text-neon">Compliance</span>
-            </h1>
+            <h1
+              className="text-5xl md:text-6xl font-bold mb-6 text-white"
+              dangerouslySetInnerHTML={{ __html: t('legal.gdpr.heroTitle') }}
+            />
             <p className="text-xl text-gray-300 mb-8 leading-relaxed">
-              Your data protection rights and our commitment to privacy compliance.
+              {t('legal.gdpr.heroSubtitle')}
             </p>
           </div>
         </div>

--- a/app/legal/privacy/page.tsx
+++ b/app/legal/privacy/page.tsx
@@ -34,7 +34,7 @@ export default function PrivacyPolicyPage() {
           <div className="flex items-center space-x-4">
             <BackToHomeButton />
             <div className="text-gray-500">/</div>
-            <div className="text-neon">Privacy Policy</div>
+            <div className="text-neon">{t('common.privacy')}</div>
           </div>
         </div>
       </header>
@@ -46,9 +46,12 @@ export default function PrivacyPolicyPage() {
             <div className="w-16 h-16 bg-gradient-to-r from-blue-500 to-cyan-500 rounded-2xl flex items-center justify-center mx-auto mb-6">
               <Shield className="w-8 h-8 text-white" />
             </div>
-            <h1 className="text-4xl md:text-5xl font-bold mb-4">Privacy Policy</h1>
+            <h1
+              className="text-4xl md:text-5xl font-bold mb-4"
+              dangerouslySetInnerHTML={{ __html: t('legal.privacy.heroTitle') }}
+            />
             <p className="text-xl text-gray-300 mb-4">
-              Your privacy is important to us. This policy explains how we collect, use, and protect your information.
+              {t('legal.privacy.heroSubtitle')}
             </p>
             <p className="text-sm text-gray-400">
               Last updated: {new Date(lastUpdated).toLocaleDateString('en-US', { 

--- a/app/legal/terms/page.tsx
+++ b/app/legal/terms/page.tsx
@@ -36,7 +36,7 @@ export default function TermsOfServicePage() {
           <div className="flex items-center space-x-4">
             <BackToHomeButton />
             <div className="text-gray-500">/</div>
-            <div className="text-neon">Terms of Service</div>
+            <div className="text-neon">{t('common.terms')}</div>
           </div>
         </div>
       </header>
@@ -48,9 +48,12 @@ export default function TermsOfServicePage() {
             <div className="w-16 h-16 bg-gradient-to-r from-purple-500 to-pink-500 rounded-2xl flex items-center justify-center mx-auto mb-6">
               <Scale className="w-8 h-8 text-white" />
             </div>
-            <h1 className="text-4xl md:text-5xl font-bold mb-4">Terms of Service</h1>
+            <h1
+              className="text-4xl md:text-5xl font-bold mb-4"
+              dangerouslySetInnerHTML={{ __html: t('legal.terms.heroTitle') }}
+            />
             <p className="text-xl text-gray-300 mb-4">
-              Legal terms and conditions governing your use of CloudFloo.io services.
+              {t('legal.terms.heroSubtitle')}
             </p>
             <p className="text-sm text-gray-400">
               Last updated: {new Date(lastUpdated).toLocaleDateString('en-US', { 

--- a/public/translations/en.json
+++ b/public/translations/en.json
@@ -349,6 +349,8 @@
     "gdpr": {
       "title": "GDPR Compliance - Data Protection | CloudFloo",
       "description": "Information about CloudFloo's GDPR compliance and personal data protection measures in cloud computing services",
+      "heroTitle": "GDPR <span class=\"text-neon\">Compliance</span>",
+      "heroSubtitle": "Your data protection rights and our commitment to privacy compliance.",
       "exercisingRights": "Exercising Your Rights",
       "exercisingRightsDesc": "To exercise your GDPR rights, you can:",
       "contactDPO": "Contact our Data Protection Officer at dpo@cloudfloo.io",
@@ -362,6 +364,8 @@
     "cookies": {
       "title": "Cookie Policy - Cookie Management | CloudFloo",
       "description": "Information about CloudFloo's cookie usage and management in cloud computing services",
+      "heroTitle": "Cookie Policy",
+      "heroSubtitle": "Learn about how we use cookies and similar technologies to improve your experience.",
       "managingCookies": "Managing Cookies",
       "managingCookiesDesc": "You have several options for managing cookies:",
       "browserSettings": "Browser Settings",
@@ -380,6 +384,8 @@
     "terms": {
       "title": "Terms of Service - Cooperation Conditions | CloudFloo",
       "description": "CloudFloo's terms of service and cooperation conditions for cloud computing services",
+      "heroTitle": "Terms of Service",
+      "heroSubtitle": "Legal terms and conditions governing your use of CloudFloo.io services",
       "userAccounts": "User Accounts",
       "userAccountsDesc": "To access certain features of our Services, you may be required to create an account. You agree to:",
       "provideAccurate": "Provide accurate, current, and complete information",
@@ -391,7 +397,9 @@
     },
     "privacy": {
       "title": "Privacy Policy - Data Protection | CloudFloo",
-      "description": "CloudFloo's privacy policy and data protection measures in cloud computing services"
+      "description": "CloudFloo's privacy policy and data protection measures in cloud computing services",
+      "heroTitle": "Privacy Policy",
+      "heroSubtitle": "Your privacy is important to us. This policy explains how we collect, use, and protect your information."
     }
   },
   "careers": {
@@ -479,6 +487,28 @@
   "languages": {
     "en": "English",
     "pl": "Polish"
+  },
+  "blog": {
+    "heroTitle": "CloudFloo <span class=\"text-neon\">Blog</span>",
+    "heroSubtitle": "Insights, tutorials, and thought leadership on cloud computing, AI, and modern software development.",
+    "featuredTitle": "Featured Posts",
+    "featuredSubtitle": "Our latest insights and deep dives into cutting-edge technology.",
+    "featured": "Featured",
+    "categories": {
+      "all": "All Posts",
+      "cloud": "Cloud Computing",
+      "ai": "AI & Machine Learning",
+      "devops": "DevOps",
+      "security": "Security",
+      "tutorials": "Tutorials"
+    },
+    "searchPlaceholder": "Search articles...",
+    "readMore": "Read More",
+    "stayUpdatedTitle": "Stay Updated",
+    "stayUpdatedSubtitle": "Subscribe to our newsletter for the latest insights and updates.",
+    "newsletterPlaceholder": "Enter your email",
+    "subscribe": "Subscribe",
+    "noPosts": "No posts found matching your criteria."
   },
   "projectWebkd": {
     "title": "WebKD: Advanced Enterprise Web Solution",

--- a/public/translations/pl.json
+++ b/public/translations/pl.json
@@ -349,6 +349,8 @@
     "gdpr": {
       "title": "Zgodność z RODO - Ochrona Danych | CloudFloo",
       "description": "Informacje o zgodności CloudFloo z RODO i środkach ochrony danych osobowych w usługach cloud computing",
+      "heroTitle": "Zgodność <span class=\"text-neon\">z RODO</span>",
+      "heroSubtitle": "Twoje prawa do ochrony danych i nasze zobowiązanie do przestrzegania RODO.",
       "exercisingRights": "Korzystanie z praw",
       "exercisingRightsDesc": "Aby skorzystać z praw wynikających z RODO, możesz:",
       "contactDPO": "Skontaktować się z naszym Inspektorem Ochrony Danych pod adresem dpo@cloudfloo.io",
@@ -362,6 +364,8 @@
     "cookies": {
       "title": "Polityka Cookies - Zarządzanie Cookies | CloudFloo",
       "description": "Informacje o używaniu i zarządzaniu cookies przez CloudFloo w usługach cloud computing",
+      "heroTitle": "Polityka Cookies",
+      "heroSubtitle": "Dowiedz się, jak używamy plików cookie i podobnych technologii, aby ulepszyć Twoje doświadczenia.",
       "managingCookies": "Zarządzanie cookies",
       "managingCookiesDesc": "Masz kilka opcji zarządzania cookies:",
       "browserSettings": "Ustawienia przeglądarki",
@@ -380,6 +384,8 @@
     "terms": {
       "title": "Regulamin Usług - Warunki Współpracy | CloudFloo",
       "description": "Regulamin usług CloudFloo i warunki współpracy dla usług cloud computing",
+      "heroTitle": "Regulamin",
+      "heroSubtitle": "Warunki prawne regulujące korzystanie z usług CloudFloo.io",
       "userAccounts": "Konta użytkowników",
       "userAccountsDesc": "Aby uzyskać dostęp do niektórych funkcji naszych Usług, może być wymagane utworzenie konta. Zgadzasz się:",
       "provideAccurate": "Podawać dokładne, aktualne i kompletne informacje",
@@ -391,7 +397,9 @@
     },
     "privacy": {
       "title": "Polityka Prywatności - Ochrona Danych | CloudFloo",
-      "description": "Polityka prywatności CloudFloo i środki ochrony danych w usługach cloud computing"
+      "description": "Polityka prywatności CloudFloo i środki ochrony danych w usługach cloud computing",
+      "heroTitle": "Polityka Prywatności",
+      "heroSubtitle": "Twoja prywatność jest dla nas ważna. Ta polityka wyjaśnia, jak zbieramy, wykorzystujemy i chronimy Twoje informacje."
     }
   },
   "careers": {
@@ -479,6 +487,28 @@
   "languages": {
     "en": "Angielski",
     "pl": "Polski"
+  },
+  "blog": {
+    "heroTitle": "CloudFloo <span class=\"text-neon\">Blog</span>",
+    "heroSubtitle": "Wgląd, tutoriale i leadership technologiczny w dziedzinie chmury, AI i nowoczesnego rozwoju oprogramowania.",
+    "featuredTitle": "Polecane wpisy",
+    "featuredSubtitle": "Najnowsze artykuły i dogłębne analizy nowoczesnych technologii.",
+    "featured": "Wyróżnione",
+    "categories": {
+      "all": "Wszystkie wpisy",
+      "cloud": "Cloud Computing",
+      "ai": "AI i uczenie maszynowe",
+      "devops": "DevOps",
+      "security": "Bezpieczeństwo",
+      "tutorials": "Poradniki"
+    },
+    "searchPlaceholder": "Szukaj artykułów...",
+    "readMore": "Czytaj dalej",
+    "stayUpdatedTitle": "Bądź na bieżąco",
+    "stayUpdatedSubtitle": "Zapisz się do naszego newslettera, aby otrzymywać najnowsze informacje i aktualizacje.",
+    "newsletterPlaceholder": "Wpisz swój email",
+    "subscribe": "Subskrybuj",
+    "noPosts": "Nie znaleziono wpisów spełniających Twoje kryteria."
   },
   "projectWebkd": {
     "title": "WebKD: Zaawansowane rozwiązanie webowe dla przedsiębiorstw",


### PR DESCRIPTION
## Summary
- add new translation keys for blog and legal pages in `en.json` and `pl.json`
- translate hero sections and texts on blog, GDPR, privacy, terms and cookies pages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6867bfc153cc8325b8be28320b25e2cc