### PR TITLE
Fix build for missing Supabase env vars

### DIFF
--- a/components/SupabaseConnectionTest.tsx
+++ b/components/SupabaseConnectionTest.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { supabase } from '@/lib/supabase/client'
+import { supabase, isSupabaseConfigured } from '@/lib/supabase/client'
 
 export function SupabaseConnectionTest() {
   const [connectionStatus, setConnectionStatus] = useState<'testing' | 'connected' | 'error'>('testing')
@@ -9,9 +9,15 @@ export function SupabaseConnectionTest() {
 
   useEffect(() => {
     const testConnection = async () => {
+      if (!isSupabaseConfigured) {
+        setConnectionStatus('error')
+        setError('Supabase not configured')
+        return
+      }
+
       try {
         console.log('🔗 Testing Supabase connection...')
-        
+
         // Test basic connection
         const { data, error } = await supabase
           .from('profiles')

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
 import { authService } from '@/lib/auth/auth.service'
+import { isSupabaseConfigured } from '@/lib/supabase/client'
 import { AuthContextType, AuthUser, SignInCredentials, SignUpCredentials, UserProfile } from '@/lib/auth/auth.types'
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
@@ -19,11 +20,15 @@ export function AuthProvider({ children }: AuthProviderProps) {
     // Check for existing session on mount
     checkUser()
 
-    // Listen for auth state changes
-    const { data: { subscription } } = authService.onAuthStateChange((authUser) => {
-      setUser(authUser)
-      setLoading(false)
-    })
+    // Listen for auth state changes when configured
+    let subscription: any
+    if (isSupabaseConfigured) {
+      const { data } = authService.onAuthStateChange((authUser) => {
+        setUser(authUser)
+        setLoading(false)
+      })
+      subscription = data?.subscription
+    }
 
     return () => {
       subscription?.unsubscribe()

--- a/lib/services/blog.service.ts
+++ b/lib/services/blog.service.ts
@@ -1,4 +1,4 @@
-import { supabase } from '@/lib/supabase/client'
+import { supabase, isSupabaseConfigured } from '@/lib/supabase/client'
 import { 
   BlogPost, 
   BlogCategory, 
@@ -81,6 +81,10 @@ export class BlogService {
 
   // Get posts with filtering and pagination
   async getPosts(params: BlogSearchParams = {}): Promise<BlogPaginatedResponse> {
+    if (!isSupabaseConfigured) {
+      console.warn('Supabase not configured: returning empty posts')
+      return { posts: [], total: 0, hasMore: false }
+    }
     const {
       status = 'published',
       category,
@@ -163,6 +167,10 @@ export class BlogService {
 
   // Get single post by slug
   async getPostBySlug(slug: string): Promise<BlogPost | null> {
+    if (!isSupabaseConfigured) {
+      console.warn('Supabase not configured: cannot fetch post')
+      return null
+    }
     const { data, error } = await supabase
       .from('blog_posts')
       .select(`
@@ -193,6 +201,10 @@ export class BlogService {
 
   // Get all categories
   async getCategories(): Promise<BlogCategory[]> {
+    if (!isSupabaseConfigured) {
+      console.warn('Supabase not configured: returning empty categories')
+      return []
+    }
     const { data, error } = await supabase
       .from('blog_categories')
       .select('*')
@@ -208,6 +220,10 @@ export class BlogService {
 
   // Search posts
   async searchPosts(query: string, limit = 10): Promise<BlogPost[]> {
+    if (!isSupabaseConfigured) {
+      console.warn('Supabase not configured: returning empty search results')
+      return []
+    }
     const { data, error } = await supabase
       .from('blog_posts')
       .select(`
@@ -254,6 +270,9 @@ export class BlogService {
   }
 
   async incrementViewCount(slug: string): Promise<void> {
+    if (!isSupabaseConfigured) {
+      return
+    }
     const { error } = await supabase.rpc('increment_view_count', { post_slug: slug })
     
     if (error) {

--- a/lib/supabase/client.ts
+++ b/lib/supabase/client.ts
@@ -2,10 +2,16 @@ import { createClient } from '@supabase/supabase-js'
 import { createBrowserClient } from '@supabase/ssr'
 import { Database } from '@/lib/types/supabase.types'
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+const supabaseUrl =
+  process.env.NEXT_PUBLIC_SUPABASE_URL || 'https://example.supabase.co'
+const supabaseAnonKey =
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || 'public-anon-key'
 
-// Client-side Supabase client
+export const isSupabaseConfigured =
+  !!process.env.NEXT_PUBLIC_SUPABASE_URL &&
+  !!process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+
+// Client-side Supabase client (uses placeholder when not configured)
 export const supabase = createBrowserClient<Database>(
   supabaseUrl,
   supabaseAnonKey
@@ -13,5 +19,8 @@ export const supabase = createBrowserClient<Database>(
 
 // Server-side Supabase client (for API routes, etc.)
 export const createServerClient = () => {
-  return createClient<Database>(supabaseUrl, supabaseAnonKey)
-} 
+  if (!isSupabaseConfigured) {
+    throw new Error('Supabase environment variables are not configured')
+  }
+  return createClient<Database>(supabaseUrl!, supabaseAnonKey!)
+}


### PR DESCRIPTION
## Summary
- handle missing Supabase credentials during build
- allow blog service to skip Supabase calls when not configured
- guard auth service and context against missing Supabase
- show message in SupabaseConnectionTest when Supabase isn't configured

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
- `npm run test:e2e` *(fails: WebServer warnings, ended manually)*
- `npm run test:a11y` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868147445088325b02768260de8b28e